### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: mountain_goat
 
 mountain_goat: mountain_goat.c layers.h layers.c
-	gcc -g -o mountain_goat mountain_goat.c layers.c -l pcap
+	gcc -g -o mountain_goat mountain_goat.c layers.c -l pcap -std=c99 -D_GNU_SOURCE
 
 
 clean:


### PR DESCRIPTION
The `-std=c99` and `-D_GNU_SOURCE` flags were required for `mountain_goat` to compile on my machine
